### PR TITLE
Add backdrop-filter fallback

### DIFF
--- a/bootstrap-override.css
+++ b/bootstrap-override.css
@@ -1,9 +1,14 @@
 .navbar {
-    background-color: #F0F0F0AB;
+    background-color: #F0F0F0F0;
     color: #950505 !important;
-    
-    -webkit-backdrop-filter: blur(30px);
-    backdrop-filter: blur(30px);
+}
+
+@supports ((-webkit-backdrop-filter: blur(30px)) or (backdrop-filter: blur(30px))) {
+    .navbar {
+        background-color: #F0F0F0AB;
+        -webkit-backdrop-filter: blur(30px);
+        backdrop-filter: blur(30px);
+    }
 }
 
 .nav-link {


### PR DESCRIPTION
Closes #2

https://github.com/Meorge/meorge.github.io/blob/d37cf31bf8d577ce8a606912411cafbed452d68f/bootstrap-override.css#L2 The navbar text is hard to read when the backdrop-filter *isn't* in effect, so a different transparency should be used instead. I think this value looks fine but feel free to submit a review.